### PR TITLE
Add a secret parameters

### DIFF
--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -8,7 +8,7 @@ class AmqpOutput < Fluent::BufferedOutput
   config_param :host, :string, default: "127.0.0.1"
   config_param :port, :integer, default: 5672
   config_param :user, :string, default: "guest"
-  config_param :password, :string, default: "guest"
+  config_param :password, :string, default: "guest", :secret => true
   config_param :vhost, :string, default: "/"
   config_param :exchange, :string, default: ""
   config_param :exchange_type, :string, default: "topic"


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature works as below:

```log
  <match pattern>
    type amqp
    host localhost
    port 5672
    user guest
    password xxxxxx
    vhost /
    exchange my_exchange
    exchange_type topic
    exchange_durable true
    payload_only false
    content_type application/octet-stream
  </match>
</ROOT>
```

When users use Fluentd 0.10 series or older, this parameter will be simply ignored.