### PR TITLE
Update gem dependency

### DIFF
--- a/fluent-plugin-amqp2.gemspec
+++ b/fluent-plugin-amqp2.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "mocha"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
 end

--- a/fluent-plugin-amqp2.gemspec
+++ b/fluent-plugin-amqp2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "fluentd", "~> 0.10.0"
+  gem.add_dependency "fluentd", [">= 0.10.0", "< 2"]
   gem.add_dependency "bunny", ">= 0.10.8"
   gem.add_dependency "yajl-ruby", "~> 1.0"
 


### PR DESCRIPTION
Fluentd 0.12 or later supports secret parameter feature and so on.
And I added `test-unit` dependency because Ruby 2.2 does not provided minitest with test-unit compatible layer.