### PR TITLE
Add option to not create the exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Or install it yourself as:
   exchange my_exchange
   exchange_type topic
   exchange_durable true # optionally set exchange durability - default is true.
+  passive false # If true, will not try to create the exchange - default is false.
   payload_only false # optional - default is false. if true, only the payload will be sent. if false, data format is { "key" => tag, "timestamp" => time, "payload" => record }.
   content_type application/octet-stream # optional - default is application/octet-stream. some amqp consumers will expect application/json.
   priority 0 # the priority for the message - requires bunny >= 1.1.6 and rabbitmq >= 3.5

--- a/lib/fluent/plugin/out_amqp.rb
+++ b/lib/fluent/plugin/out_amqp.rb
@@ -13,6 +13,7 @@ class AmqpOutput < Fluent::BufferedOutput
   config_param :exchange, :string, default: ""
   config_param :exchange_type, :string, default: "topic"
   config_param :exchange_durable, :bool, default: true
+  config_param :passive, :bool, default: false
   config_param :payload_only, :bool, default: false
   config_param :content_type, :string, default: "application/octet-stream"
   config_param :priority, :integer, default: nil
@@ -85,7 +86,7 @@ class AmqpOutput < Fluent::BufferedOutput
 
     unless @amqp_channel && @amqp_channel.open?
       @amqp_channel  = @amqp_conn.create_channel
-      @amqp_exchange = Bunny::Exchange.new(@amqp_channel, @exchange_type.to_sym, @exchange_name, durable: @exchange_durable)
+      @amqp_exchange = Bunny::Exchange.new(@amqp_channel, @exchange_type.to_sym, @exchange_name, durable: @exchange_durable, no_declare: @passive)
     end
 
     @amqp_exchange


### PR DESCRIPTION
Hello @abecciu,

I'm creating a setup with fluentd in which I can't loose any log messages. So to help me do this I'm using the alternate-exchange option of RabbitMQ, this way I can find out any unrouted messages and this makes it very easy to discover any problems with missing messages.

Also it enables a more dynamic setup where I don't need to change my binding whenever a new routing key begins to be used.

Let me know what do you think and if you need anything to me adjusted.

Thanks,